### PR TITLE
Build update

### DIFF
--- a/bld/Macros.nci
+++ b/bld/Macros.nci
@@ -26,9 +26,9 @@ FREEFLAGS  :=
 #FFLAGS     := -v -g -convert big_endian -r8 -i4 -check -ftrapuv -assume byterecl -gen-interfaces
 
 ifeq ($(DEBUG), yes)
-    FFLAGS     := -r8 -i4 -O0 -traceback -g -debug all -no-vec -align all -w -fpe0 -ftz -convert big_endian -assume byterecl -no-vec -mcmodel=medium -assume buffered_io -check noarg_temp_created
+    FFLAGS     := -r8 -i4 -O0 -traceback -g -debug all -no-vec -align all -w -fpe0 -ftz -convert big_endian -assume byterecl -no-vec -assume buffered_io -check noarg_temp_created
 else
-    FFLAGS     := -r8 -i4 -O3 -align all -g -fpe0 -w -ftz -convert big_endian -assume byterecl -mcmodel=medium -assume buffered_io -check noarg_temp_created
+    FFLAGS     := -r8 -i4 -O3 -align all -g -fpe0 -w -ftz -convert big_endian -assume byterecl -assume buffered_io -check noarg_temp_created
 endif
 #FFLAGS     := -r8 -i4 -O2 -align all -w -ftz -convert big_endian -assume byterecl -mp -g
 #FFLAGS     := -r8 -i4 -O2 -align all -w -ftz -convert big_endian -assume byterecl -fpe0 -CB -g

--- a/bld/build.sh
+++ b/bld/build.sh
@@ -39,9 +39,13 @@ setenv OASIS3_MCT yes	  # oasis3-mct version
 ### Location and names of coupling libraries and inclusions
 if ( $AusCOM == 'yes' ) then
     # Location and names of coupling libraries
-    setenv CPLLIBDIR $SRCDIR/../coupler/Linux/lib
+    #setenv CPLLIBDIR $SRCDIR/../coupler/Linux/lib
+    #setenv CPLLIBS '-L$(CPLLIBDIR) -lpsmile.MPI1 -lmct -lmpeu -lscrip'
+    #setenv CPLINCDIR $SRCDIR/../coupler/Linux/build/lib
+    #setenv CPL_INCS '-I$(CPLINCDIR)/psmile.MPI1 -I$(CPLINCDIR)/pio -I$(CPLINCDIR)/mct'
+    setenv CPLLIBDIR $OASIS/lib
     setenv CPLLIBS '-L$(CPLLIBDIR) -lpsmile.MPI1 -lmct -lmpeu -lscrip'
-    setenv CPLINCDIR $SRCDIR/../coupler/Linux/build/lib
+    setenv CPLINCDIR $OASIS/include
     setenv CPL_INCS '-I$(CPLINCDIR)/psmile.MPI1 -I$(CPLINCDIR)/pio -I$(CPLINCDIR)/mct'
 endif
  

--- a/bld/config.nci.360x300
+++ b/bld/config.nci.360x300
@@ -10,7 +10,9 @@ setenv BLCKY `expr $NYGLOB / 1`       # y-dimension of blocks (  ghost cells  )
 
 source /etc/profile.d/nf_csh_modules
 module purge
-module load intel-cc
-module load intel-fc
+module load intel-cc/14.3.174
+module load intel-fc/14.3.174
+module load intel-mkl/14.3.174
 module load netcdf
 module load openmpi/1.6.5-mlx
+module load oasis/dev


### PR DESCRIPTION
build changes to use oasis module
also upgraded intel compiler to match oasis lib

mcmodel=medium no longer works with -static-intel so it was removed. this could cause issues with large cpu jobs in the future.
